### PR TITLE
Update glob-parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "glob-parent": "^1.2.0"
+    "glob-parent": "^2.0.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Will prevent messages like the following when I publish the next chokidar with updated deps:

```
npm WARN unmet dependency /Users/eshanker/Code/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/parse-glob/node_modules/glob-base requires glob-parent@'^1.2.0' but will load
npm WARN unmet dependency /Users/eshanker/Code/chokidar/node_modules/glob-parent,
npm WARN unmet dependency which is version 2.0.0
glob-parent@2.0.0 node_modules/glob-parent
```
