### PR TITLE
Update glob-parent

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@
 
 var path = require('path');
 var parent = require('glob-parent');
+var isGlob = require('is-glob');
 
 module.exports = function globBase(pattern) {
   if (typeof pattern !== 'string') {
@@ -17,7 +18,7 @@ module.exports = function globBase(pattern) {
 
   var res = {};
   res.base = parent(pattern);
-  res.isGlob = res.base !== pattern;
+  res.isGlob = isGlob(pattern);
 
   if (res.base !== '.') {
     res.glob = pattern.substr(res.base.length);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "glob-parent": "^1.2.0"
+    "glob-parent": "^2.0.0",
+    "is-glob": "^2.0.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
The existing methodology is totally reliant on [`res.isGlob = res.base !== pattern;`](https://github.com/jonschlinkert/glob-base/blob/7d8c1b557a424983cf6bab7ad03149d2f55257a0/index.js#L20), but since glob-parent does other manipulations to non-glob paths now it's no longer analogous. Using is-glob directly was the most straightforward solution that avoided having to rearrange how everything else worked.
